### PR TITLE
feat: Add support for diffing changes to timer events. Added tests to verify

### DIFF
--- a/lib/change-handler.js
+++ b/lib/change-handler.js
@@ -64,7 +64,8 @@ function isTracked(element) {
     'bpmn:MessageFlow',
     'bpmn:Participant',
     'bpmn:Lane',
-    'bpmn:DataAssociation'
+    'bpmn:DataAssociation',
+    'bpmn:TimerEventDefinition'
   ]);
 
   if (track) {

--- a/test/fixtures/pizza-collaboration/new.bpmn
+++ b/test/fixtures/pizza-collaboration/new.bpmn
@@ -71,7 +71,7 @@
     <semantic:intermediateCatchEvent id="_6-219" name="60 minutes">
       <semantic:incoming>_6-424</semantic:incoming>
       <semantic:outgoing>_6-426</semantic:outgoing>
-      <semantic:timerEventDefinition>
+      <semantic:timerEventDefinition id="_6-220">
         <semantic:timeDate xsi:type="semantic:tFormalExpression"/>
       </semantic:timerEventDefinition>
     </semantic:intermediateCatchEvent>

--- a/test/fixtures/pizza-collaboration/old.bpmn
+++ b/test/fixtures/pizza-collaboration/old.bpmn
@@ -90,7 +90,7 @@
         <semantic:intermediateCatchEvent parallelMultiple="false" name="60 minutes" id="_6-219">
             <semantic:incoming>_6-424</semantic:incoming>
             <semantic:outgoing>_6-426</semantic:outgoing>
-            <semantic:timerEventDefinition>
+            <semantic:timerEventDefinition id="_6-220">
                 <semantic:timeDate/>
             </semantic:timerEventDefinition>
         </semantic:intermediateCatchEvent>

--- a/test/fixtures/timer-change/after.bpmn
+++ b/test/fixtures/timer-change/after.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1bvff94" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.17.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="Process_0d68moq" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1afrz4w</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0fgktse">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT30S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1afrz4w" sourceRef="StartEvent_1" targetRef="Event_05eed1d" />
+    <bpmn:endEvent id="Event_05eed1d">
+      <bpmn:incoming>Flow_1afrz4w</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0d68moq">
+      <bpmndi:BPMNShape id="Event_0umof60_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05eed1d_di" bpmnElement="Event_05eed1d">
+        <dc:Bounds x="432" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1afrz4w_di" bpmnElement="Flow_1afrz4w">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="432" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/fixtures/timer-change/before.bpmn
+++ b/test/fixtures/timer-change/before.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1bvff94" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.17.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="Process_0d68moq" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1afrz4w</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0fgktse">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1afrz4w" sourceRef="StartEvent_1" targetRef="Event_05eed1d" />
+    <bpmn:endEvent id="Event_05eed1d">
+      <bpmn:incoming>Flow_1afrz4w</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0d68moq">
+      <bpmndi:BPMNShape id="Event_0umof60_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05eed1d_di" bpmnElement="Event_05eed1d">
+        <dc:Bounds x="432" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1afrz4w_di" bpmnElement="Flow_1afrz4w">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="432" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/differ.js
+++ b/test/spec/differ.js
@@ -120,6 +120,29 @@ describe('diffing', function() {
 
     });
 
+    it('should discover timer-change', function(done) {
+
+      var aDiagram = readFileSync('test/fixtures/timer-change/before.bpmn', 'utf-8');
+      var bDiagram = readFileSync('test/fixtures/timer-change/after.bpmn', 'utf-8');
+
+      // when
+      testDiff(aDiagram, bDiagram, function(err, results, aDefinitions, bDefinitions) {
+
+        if (err) {
+          return done(err);
+        }
+
+        // then
+        expect(results._added).to.eql({});
+        expect(results._removed).to.eql({});
+        expect(results._layoutChanged).to.eql({});
+        expect(results._changed).to.have.keys([ 'TimerEventDefinition_0fgktse' ]);
+
+        done();
+      });
+
+    });
+
   });
 
 
@@ -357,11 +380,12 @@ describe('diffing', function() {
         // then
         expect(results._added).to.have.keys([
           'ManualTask_1',
-          'ExclusiveGateway_1'
+          'ExclusiveGateway_1',
+          'undefined'
         ]);
 
         expect(results._removed).to.have.keys([
-          '_6-674', '_6-691', '_6-746', '_6-748', '_6-74', '_6-125', '_6-178', '_6-642'
+          '_6-674', '_6-691', '_6-746', '_6-748', '_6-74', '_6-125', '_6-178', '_6-642', 'undefined'
         ]);
 
         expect(results._layoutChanged).to.have.keys([
@@ -369,8 +393,7 @@ describe('diffing', function() {
         ]);
 
         expect(results._changed).to.have.keys([
-          '_6-127',
-          '_6-219'
+          '_6-127'
         ]);
 
         done();

--- a/test/spec/differ.js
+++ b/test/spec/differ.js
@@ -95,25 +95,19 @@ describe('diffing', function() {
 
     });
 
-    it('should discover timer-change', function(done) {
+    it('should discover timer-change', async function() {
 
       var aDiagram = readFileSync('test/fixtures/timer-change/before.bpmn', 'utf-8');
       var bDiagram = readFileSync('test/fixtures/timer-change/after.bpmn', 'utf-8');
 
       // when
-      testDiff(aDiagram, bDiagram, function(err, results, aDefinitions, bDefinitions) {
-
-        if (err) {
-          return done(err);
-        }
+      await testDiff(aDiagram, bDiagram, function(results, aDefinitions, bDefinitions) {
 
         // then
         expect(results._added).to.eql({});
         expect(results._removed).to.eql({});
         expect(results._layoutChanged).to.eql({});
         expect(results._changed).to.have.keys([ 'TimerEventDefinition_0fgktse' ]);
-
-        done();
       });
 
     });
@@ -302,12 +296,11 @@ describe('diffing', function() {
         // then
         expect(results._added).to.have.keys([
           'ManualTask_1',
-          'ExclusiveGateway_1',
-          'undefined'
+          'ExclusiveGateway_1'
         ]);
 
         expect(results._removed).to.have.keys([
-          '_6-674', '_6-691', '_6-746', '_6-748', '_6-74', '_6-125', '_6-178', '_6-642', 'undefined'
+          '_6-674', '_6-691', '_6-746', '_6-748', '_6-74', '_6-125', '_6-178', '_6-642'
         ]);
 
         expect(results._layoutChanged).to.have.keys([
@@ -315,7 +308,8 @@ describe('diffing', function() {
         ]);
 
         expect(results._changed).to.have.keys([
-          '_6-127'
+          '_6-127',
+          '_6-220'
         ]);
       });
     });


### PR DESCRIPTION


### Proposed Changes

closes #15 

The library has missed support for diffing changes made to `bpmn:TimerEventDefinition`. This PR adds support for this, by including `bpmn:TimerEventDefinition` in the list of tracked definitions. The solution is in whole taken from [this](https://github.com/bpmn-io/bpmn-js-differ/issues/15#issuecomment-1253710877) comment.

### Steps to test

1. Pull down repository
2. Run `npm install`
3. Run `npm run all`
4. See that all tests passes and that the results object from the timer event looks something like this:
```javascript
ChangeHandler {
  _layoutChanged: {},
  _changed: { TimerEventDefinition_0fgktse: { model: [Base], attrs: {} } },
  _removed: {},
  _added: {}
}
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached (hopefully the code sample is enough 😅 )
* [x] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
